### PR TITLE
[!!!][BUGFIX] Fix fe_groups lookup by ip address

### DIFF
--- a/Classes/EventListener/ModifyFeGroups.php
+++ b/Classes/EventListener/ModifyFeGroups.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AOE\AoeIpauth\EventListener;
+
+use AOE\AoeIpauth\Domain\Service\FeEntityService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Authentication\ModifyResolvedFrontendGroupsEvent;
+
+class ModifyFeGroups
+{
+    public function __invoke(ModifyResolvedFrontendGroupsEvent $event): void
+    {
+        $ip = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+        $feEntityService = GeneralUtility::makeInstance(FeEntityService::class);
+        $groups = $feEntityService->findAllGroupsAuthenticatedByIp($ip);
+        if (!empty($groups)) {
+            $newGroups = array_merge($event->getGroups(), $groups);
+            $event->setGroups($newGroups);
+        }
+    }
+}

--- a/Classes/Typo3/Service/Authentication.php
+++ b/Classes/Typo3/Service/Authentication.php
@@ -147,32 +147,6 @@ class Authentication extends AbstractAuthenticationService
     }
 
     /**
-     * Get the group list
-     *
-     * @param string $user
-     * @param array $knownGroups
-     * @return array
-     */
-    public function getGroups($user, $knownGroups)
-    {
-        // Do not respond to non-FE group calls
-        if ('getGroupsFE' != $this->mode) {
-            return $knownGroups;
-        }
-
-        $this->safeguardContext();
-
-        $clientIp = $this->authInfo['REMOTE_ADDR'];
-        $ipAuthenticatedGroups = $this->findAllGroupsByIpAuthentication($clientIp);
-
-        if (!empty($ipAuthenticatedGroups)) {
-            $knownGroups = array_merge($ipAuthenticatedGroups, $knownGroups);
-        }
-
-        return $knownGroups;
-    }
-
-    /**
      * Returns TRUE if the userId's associated IPs match the client IP
      *
      * @param int $userId
@@ -203,18 +177,6 @@ class Authentication extends AbstractAuthenticationService
     {
         $users = $this->getFeEntityService()->findAllUsersAuthenticatedByIp($ip);
         return $users;
-    }
-
-    /**
-     * Finds all groups with IP authentication enabled
-     *
-     * @param string $ip
-     * @return array
-     */
-    protected function findAllGroupsByIpAuthentication($ip)
-    {
-        $groups = $this->getFeEntityService()->findAllGroupsAuthenticatedByIp($ip);
-        return $groups;
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,14 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  AOE\AoeIpauth\:
+    resource: '../Classes/*'
+
+  AOE\AoeIpauth\EventListener\ModifyFeGroups:
+    tags:
+      - name: event.listener
+        identifier: 'modifyFeGroupsListener'
+        event: TYPO3\CMS\Frontend\Authentication\ModifyResolvedFrontendGroupsEvent

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "issues": "https://github.com/AOEpeople/aoe_ipauth/issues"
   },
   "require": {
-    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5"
+    "typo3/cms-core": "^11.5"
   },
   "require-dev": {
     "nimut/testing-framework": "^5.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '3.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-11.5.99',
+            'typo3' => '11.5.0-11.5.99',
         ],
         'conflicts' => [
         ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,7 +25,7 @@ defined('TYPO3') or die();
         array(
             'title' => 'IP Authentication',
             'description' => 'Authenticates against IP addresses and ranges.',
-            'subtype' => 'authUserFE,getUserFE,getGroupsFE',
+            'subtype' => 'authUserFE,getUserFE',
             'available' => true,
             // Must be higher than for tx_sv_auth (50) or tx_sv_auth will deny request unconditionally
             'priority' => 80,


### PR DESCRIPTION
This change fixes the fe_groups lookup by ip address. It however also removes compatibility to TYPO3 9.5 and 10.4, since the `ModifyResolvedFrontendGroupsEvent` is only available in TYPO3 11.5